### PR TITLE
Fixed bug in orient_d reading

### DIFF
--- a/lib/modules/hat.py
+++ b/lib/modules/hat.py
@@ -19,7 +19,7 @@ class Hat(object):
 
         # IMU (inertial measurement unit) sensors
         orient_r = self.sense.orientation_radians
-        orient_d = self.sense.orientation_degrees
+        orient_d = self.sense.orientation
         compass = self.sense.compass
         compass_r = self.sense.compass_raw
         gyro = self.sense.gyroscope


### PR DESCRIPTION
The sensehat library uses "orientation" as the shorthand for get_orientation_degrees(), not "orientation_degrees" as the shorthand for radians would lead you to think. Without the change, the hat module crashes at the first read.